### PR TITLE
chore: add refresh-token functionality

### DIFF
--- a/server/auth-service/src/main/java/shopsphere_authservice/controller/AuthController.java
+++ b/server/auth-service/src/main/java/shopsphere_authservice/controller/AuthController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import shopsphere_authservice.dto.request.GoogleLoginRequest;
 import shopsphere_authservice.dto.request.LoginRequest;
+import shopsphere_authservice.dto.request.RefreshTokenRequest;
 import shopsphere_authservice.dto.request.RegisterRequest;
 import shopsphere_authservice.dto.response.UserResponse;
 import shopsphere_authservice.enums.UserRole;
@@ -34,7 +35,12 @@ public class AuthController {
     }
 
     @PostMapping("/google-login")
-    public ResponseEntity<UserResponse> googleLogin(@RequestBody GoogleLoginRequest request) {
+    public ResponseEntity<UserResponse> googleLogin(@RequestBody @Valid GoogleLoginRequest request) {
         return ResponseEntity.ok(authService.googleLogin(request, UserRole.USER));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<UserResponse> refreshToken(@RequestBody @Valid RefreshTokenRequest request) {
+        return ResponseEntity.ok(authService.refreshToken(request));
     }
 }

--- a/server/auth-service/src/main/java/shopsphere_authservice/dto/request/GoogleLoginRequest.java
+++ b/server/auth-service/src/main/java/shopsphere_authservice/dto/request/GoogleLoginRequest.java
@@ -1,8 +1,10 @@
 package shopsphere_authservice.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class GoogleLoginRequest {
-    private String idToken;
+    @NotBlank(message = "id_token is required")
+    private String id_token;
 }

--- a/server/auth-service/src/main/java/shopsphere_authservice/dto/request/RefreshTokenRequest.java
+++ b/server/auth-service/src/main/java/shopsphere_authservice/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,8 @@
+package shopsphere_authservice.dto.request;
+
+import lombok.Data;
+
+@Data
+public class RefreshTokenRequest {
+    private String token;
+}

--- a/server/auth-service/src/main/java/shopsphere_authservice/dto/response/UserResponse.java
+++ b/server/auth-service/src/main/java/shopsphere_authservice/dto/response/UserResponse.java
@@ -1,3 +1,3 @@
 package shopsphere_authservice.dto.response;
 
-public record UserResponse(String access_token) {}
+public record UserResponse(String access_token, String refresh_token) {}

--- a/server/auth-service/src/main/java/shopsphere_authservice/entity/RefreshToken.java
+++ b/server/auth-service/src/main/java/shopsphere_authservice/entity/RefreshToken.java
@@ -1,0 +1,28 @@
+package shopsphere_authservice.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "refresh_token")
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private Instant expiryDate;
+}

--- a/server/auth-service/src/main/java/shopsphere_authservice/repository/RefreshTokenRepository.java
+++ b/server/auth-service/src/main/java/shopsphere_authservice/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package shopsphere_authservice.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shopsphere_authservice.entity.RefreshToken;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    void deleteByEmail(String email);
+}

--- a/server/auth-service/src/main/java/shopsphere_authservice/service/RefreshTokenService.java
+++ b/server/auth-service/src/main/java/shopsphere_authservice/service/RefreshTokenService.java
@@ -1,0 +1,43 @@
+package shopsphere_authservice.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import shopsphere_authservice.entity.RefreshToken;
+import shopsphere_authservice.repository.RefreshTokenRepository;
+import shopsphere_authservice.utils.JwtUtils;
+import shopsphere_shared.exceptions.UnauthorizedException;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final JwtUtils jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public String createRefreshToken(String email) {
+        long refreshTokenDurationMs = TimeUnit.DAYS.toMillis(7);
+
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken(jwtUtil.generateRefreshToken(email));
+        refreshToken.setEmail(email);
+        refreshToken.setExpiryDate(Instant.now()
+                .plusMillis(refreshTokenDurationMs));
+
+        refreshTokenRepository.deleteByEmail(email);
+        refreshTokenRepository.save(refreshToken);
+
+        return refreshToken.getToken();
+    }
+
+    public void validateRefreshToken(String token) {
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(token)
+                .orElseThrow(() -> new UnauthorizedException("invalid refresh token"));
+
+        if (refreshToken.getExpiryDate().isBefore(Instant.now())) {
+            throw new UnauthorizedException("refresh token expired");
+        }
+    }
+}

--- a/server/auth-service/src/main/java/shopsphere_authservice/utils/JwtUtils.java
+++ b/server/auth-service/src/main/java/shopsphere_authservice/utils/JwtUtils.java
@@ -1,5 +1,6 @@
 package shopsphere_authservice.utils;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 public class JwtUtils {
 
     private static final long JWT_TOKEN_VALID_TIME = TimeUnit.HOURS.toMillis(1);
+    private static final long REFRESH_TOKEN_VALID_TIME = TimeUnit.DAYS.toMillis(7);
 
     @Value("${jwt.secret}")
     private String secret;
@@ -26,6 +28,24 @@ public class JwtUtils {
                 .expiration(new Date(System.currentTimeMillis() + JWT_TOKEN_VALID_TIME))
                 .signWith(generateSigningKey())
                 .compact();
+    }
+
+    public String generateRefreshToken(String email) {
+        return Jwts.builder()
+                .subject(email)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_VALID_TIME))
+                .signWith(generateSigningKey())
+                .compact();
+    }
+
+    public String validateToken(String token) {
+        return Jwts.parser()
+                .verifyWith(generateSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
     }
 
     private SecretKey generateSigningKey() {

--- a/server/auth-service/src/test/java/shopsphere_authservice/controller/AuthControllerTest.java
+++ b/server/auth-service/src/test/java/shopsphere_authservice/controller/AuthControllerTest.java
@@ -222,7 +222,9 @@ class AuthControllerTest {
                     .password("P@ssword98")
                     .build();
 
-            when(authService.login(request)).thenReturn(new UserResponse("dummy-token"));
+            UserResponse token = new UserResponse("dummy-token", "refresh-token");
+
+            when(authService.login(request)).thenReturn(token);
             String requestString = objectMapper.writeValueAsString(request);
 
             mockMvc.perform(post("/api/v1/auth/login")
@@ -230,7 +232,8 @@ class AuthControllerTest {
                             .content(requestString))
                     .andExpect(status().isOk())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$.access_token").value("dummy-token"));
+                    .andExpect(jsonPath("$.access_token").value("dummy-token"))
+                    .andExpect(jsonPath("$.refresh_token").value(token.refresh_token()));
         }
 
         @Test
@@ -272,10 +275,10 @@ class AuthControllerTest {
         @Test
         void googleLogin_success() throws Exception {
             GoogleLoginRequest request = new GoogleLoginRequest();
-            request.setIdToken("id-token");
+            request.setId_token("id-token");
 
             when(authService.googleLogin(eq(request), any(UserRole.class)))
-                    .thenReturn(new UserResponse("dummy-token"));
+                    .thenReturn(new UserResponse("dummy-token", "dummy-refresh-token"));
 
             String requestString = objectMapper.writeValueAsString(request);
             mockMvc.perform(post("/api/v1/auth/google-login")
@@ -283,7 +286,8 @@ class AuthControllerTest {
                             .content(requestString))
                     .andExpect(status().isOk())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$.access_token").value("dummy-token"));
+                    .andExpect(jsonPath("$.access_token").value("dummy-token"))
+                    .andExpect(jsonPath("$.refresh_token").value("dummy-refresh-token"));
         }
     }
 }

--- a/server/auth-service/src/test/java/shopsphere_authservice/controller/VendorControllerTest.java
+++ b/server/auth-service/src/test/java/shopsphere_authservice/controller/VendorControllerTest.java
@@ -20,7 +20,6 @@ import shopsphere_authservice.service.AuthService;
 import shopsphere_shared.exceptions.ConflictException;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -216,10 +215,11 @@ class VendorControllerTest {
         @Test
         void googleLogin_success() throws Exception {
             GoogleLoginRequest request = new GoogleLoginRequest();
-            request.setIdToken("id-token");
+            request.setId_token("id-token");
 
-            when(authService.googleLogin(request, UserRole.VENDOR))
-                    .thenReturn(new UserResponse("dummy-token"));
+            UserResponse token = new UserResponse("dummy-token", "refresh-token");
+
+            when(authService.googleLogin(request, UserRole.VENDOR)).thenReturn(token);
 
             String requestString = objectMapper.writeValueAsString(request);
             mockMvc.perform(post("/api/v1/auth/vendor/google-login")
@@ -227,7 +227,8 @@ class VendorControllerTest {
                             .content(requestString))
                     .andExpect(status().isOk())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$.access_token").value("dummy-token"));
+                    .andExpect(jsonPath("$.access_token").value("dummy-token"))
+                    .andExpect(jsonPath("$.refresh_token").value(token.refresh_token()));
         }
     }
 }

--- a/server/auth-service/src/test/java/shopsphere_authservice/service/RefreshTokenServiceTest.java
+++ b/server/auth-service/src/test/java/shopsphere_authservice/service/RefreshTokenServiceTest.java
@@ -1,0 +1,104 @@
+package shopsphere_authservice.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import shopsphere_authservice.entity.RefreshToken;
+import shopsphere_authservice.repository.RefreshTokenRepository;
+import shopsphere_authservice.utils.JwtUtils;
+import shopsphere_shared.exceptions.UnauthorizedException;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+    @Mock private JwtUtils jwtUtil;
+    @Mock private RefreshTokenRepository refreshRepository;
+    @InjectMocks private RefreshTokenService underTest;
+
+    @Test
+    void createRefreshTokenTest() {
+        when(jwtUtil.generateRefreshToken("test@user.com"))
+                .thenReturn("dummy-refresh-token");
+        when(refreshRepository.save(any(RefreshToken.class))).thenAnswer(invocation -> {
+            RefreshToken token = invocation.getArgument(0);
+
+            return RefreshToken.builder()
+                    .id(5L)
+                    .token(token.getToken())
+                    .email(token.getEmail())
+                    .expiryDate(token.getExpiryDate())
+                    .build();
+        });
+
+        String response = underTest.createRefreshToken("test@user.com");
+        ArgumentCaptor<RefreshToken> argumentCaptor = ArgumentCaptor.forClass(RefreshToken.class);
+
+        verify(refreshRepository).save(argumentCaptor.capture());
+        RefreshToken capturedEntry = argumentCaptor.getValue();
+
+        assertEquals("test@user.com", capturedEntry.getEmail());
+        assertEquals("dummy-refresh-token", capturedEntry.getToken());
+        assertNotNull(capturedEntry.getExpiryDate());
+
+        assertEquals("dummy-refresh-token", response);
+
+        verify(jwtUtil).generateRefreshToken(anyString());
+        verify(refreshRepository).save(any(RefreshToken.class));
+        verify(refreshRepository).deleteByEmail(anyString());
+    }
+
+    @Test
+    void validateRefreshToken_success() {
+        RefreshToken token = RefreshToken.builder()
+                .id(5L)
+                .token("dummy-token")
+                .email("test@user.com")
+                .expiryDate(Instant.now().plusSeconds(1000))
+                .build();
+
+        when(refreshRepository.findByToken(anyString())).thenReturn(Optional.of(token));
+
+        assertDoesNotThrow(()-> underTest.validateRefreshToken(token.getToken()));
+        verify(refreshRepository).findByToken(anyString());
+    }
+
+    @Test
+    void validateRefreshToken_invalidToken() {
+        when(refreshRepository.findByToken(anyString())).thenReturn(Optional.empty());
+
+        Exception ex =  assertThrows(UnauthorizedException.class,
+                () -> underTest.validateRefreshToken("dummy-token"));
+
+        assertEquals("invalid refresh token", ex.getMessage());
+        verify(refreshRepository).findByToken(anyString());
+    }
+
+    @Test
+    void validateRefreshToken_expiredToken() {
+        RefreshToken token = RefreshToken.builder()
+                .id(5L)
+                .token("dummy-token")
+                .email("test@user.com")
+                .expiryDate(Instant.now().minusSeconds(1000))
+                .build();
+
+        when(refreshRepository.findByToken(anyString())).thenReturn(Optional.of(token));
+        Exception ex =  assertThrows(UnauthorizedException.class,
+                () -> underTest.validateRefreshToken("dummy-token"));
+
+        assertEquals("refresh token expired", ex.getMessage());
+        verify(refreshRepository).findByToken(anyString());
+    }
+}


### PR DESCRIPTION
**Description**
extend the auth-service to add the refresh token functionality. When user register or authenticates, the access-token and the refresh token is returned. The refresh token can be used to issue a new access token without re-login when the access token expires.