### PR TITLE
fix: add script to copy workflow to root

### DIFF
--- a/.github/workflows/server-ci.yaml
+++ b/.github/workflows/server-ci.yaml
@@ -2,9 +2,13 @@ name: Server CI Orchestrator
 
 on:
   push:
+    branches:
+      - 'main'
     paths:
       - 'server/**'
   pull_request:
+    branches:
+      - 'main'
     paths:
       - 'server/**'
 
@@ -17,7 +21,7 @@ jobs:
 
       - name: setup workflows
         run: ./setup-workflows/sh
-        
+
   auth-service:
     uses: ./.github/workflows/auth-service-ci.yaml
     with:

--- a/.github/workflows/server-ci.yaml
+++ b/.github/workflows/server-ci.yaml
@@ -9,8 +9,17 @@ on:
       - 'server/**'
 
 jobs:
+  setup-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+
+      - name: setup workflows
+        run: ./setup-workflows/sh
+        
   auth-service:
-    uses: ./server/.github/workflows/auth-service-ci.yaml
+    uses: ./.github/workflows/auth-service-ci.yaml
     with:
       service-name: auth-service
     secrets:

--- a/setup-workflows.sh
+++ b/setup-workflows.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+mkdir -p .github/workflows
+
+echo "Copying Server workflows..."
+cp -R server/.github/workflows/* .github/workflows/
+
+echo "workflows have been set up successfully."


### PR DESCRIPTION
**Description**
This pr attempts to solve the workflow run failure caused due to workflow referencing a workflow in a different directory

**what was done**
a script is provided to copy the workflow from server directory to the root directory ensuring the workflow remains clean

closes #24 